### PR TITLE
Create single GroupViTEncoderLayer class

### DIFF
--- a/src/transformers/models/groupvit/configuration_groupvit.py
+++ b/src/transformers/models/groupvit/configuration_groupvit.py
@@ -208,8 +208,8 @@ class GroupViTVisionConfig(PretrainedConfig):
         num_channels=3,
         hidden_act="gelu",
         layer_norm_eps=1e-5,
-        hidden_dropout_prob=0.0,
-        attention_probs_dropout_prob=0.0,
+        dropout=0.0,
+        attention_dropout=0.0,
         initializer_range=0.02,
         initializer_factor=1.0,
         assign_eps=1.0,
@@ -222,27 +222,27 @@ class GroupViTVisionConfig(PretrainedConfig):
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.depths = depths
-        self.num_group_tokens = num_group_tokens
-        self.num_output_groups = num_output_groups
-        self.hidden_dropout_prob = hidden_dropout_prob
-        self.num_attention_heads = num_attention_heads
-        self.patch_size = patch_size
-        self.num_channels = num_channels
-        self.image_size = image_size
-        self.initializer_range = initializer_range
-        self.initializer_factor = initializer_factor
-        self.attention_probs_dropout_prob = attention_probs_dropout_prob
-        self.layer_norm_eps = layer_norm_eps
-        self.hidden_act = hidden_act
-        self.assign_eps = assign_eps
-        self.assign_mlp_ratio = assign_mlp_ratio
-        self.qkv_bias = qkv_bias
-        self.num_hidden_layers = num_hidden_layers
         if num_hidden_layers != sum(depths):
             logger.warning(
                 f"Manually setting num_hidden_layers to {num_hidden_layers}, but we expect num_hidden_layers ="
                 f" sum(depth) = {sum(depths)}"
             )
+        self.num_hidden_layers = num_hidden_layers
+        self.num_group_tokens = num_group_tokens
+        self.num_output_groups = num_output_groups
+        self.num_attention_heads = num_attention_heads
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.num_channels = num_channels
+        self.hidden_act = hidden_act
+        self.layer_norm_eps = layer_norm_eps
+        self.dropout = dropout
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+        self.initializer_factor = initializer_factor
+        self.assign_eps = assign_eps
+        self.assign_mlp_ratio = assign_mlp_ratio
+        self.qkv_bias = qkv_bias
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs) -> "PretrainedConfig":

--- a/src/transformers/models/groupvit/convert_groupvit_nvlab_to_hf.py
+++ b/src/transformers/models/groupvit/convert_groupvit_nvlab_to_hf.py
@@ -22,10 +22,10 @@ URL: https://github.com/NVlabs/GroupViT
 import argparse
 
 import torch
-import torch.nn.functional as F
+from PIL import Image
 
-from regex import E
-from transformers import GroupViTConfig, GroupViTModel
+import requests
+from transformers import CLIPProcessor, GroupViTConfig, GroupViTModel
 
 
 def rename_key(name):
@@ -35,16 +35,18 @@ def rename_key(name):
     if "img_encoder.patch_embed.proj" in name:
         name = name.replace("img_encoder.patch_embed.proj", "vision_model.embeddings.patch_embeddings.projection")
     if "img_encoder.patch_embed.norm" in name:
-        name = name.replace("img_encoder.patch_embed.norm", "vision_model.embeddings.patch_embeddings.layernorm")
+        name = name.replace("img_encoder.patch_embed.norm", "vision_model.embeddings.layernorm")
     if "img_encoder.layers" in name:
         name = name.replace("img_encoder.layers", "vision_model.encoder.stages")
     if "blocks" in name and "res" not in name:
         name = name.replace("blocks", "layers")
     if "attn" in name and "pre_assign" not in name:
         name = name.replace("attn", "self_attn")
+    if "proj" in name and "self_attn" in name and "text" not in name:
+        name = name.replace("proj", "out_proj")
     if "norm1" in name:
         name = name.replace("norm1", "layer_norm1")
-    if "norm2" in name:
+    if "norm2" in name and "pre_assign" not in name:
         name = name.replace("norm2", "layer_norm2")
     if "img_encoder.norm" in name:
         name = name.replace("img_encoder.norm", "vision_model.layernorm")
@@ -80,13 +82,52 @@ def rename_key(name):
     return name
 
 
-def convert_state_dict(orig_state_dict):
+def convert_state_dict(orig_state_dict, config):
     for key in orig_state_dict.copy().keys():
         val = orig_state_dict.pop(key)
 
-        # attention requires special treatment
         if "qkv" in key:
-            pass
+            # weights and biases of the key, value and query projections of vision encoder's attention layers require special treatment:
+            # we need to split them up into separate matrices/vectors
+            key_split = key.split(".")
+            stage_num, layer_num = int(key_split[2]), int(key_split[4])
+            dim = config.vision_config.hidden_size
+            if "weight" in key:
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.q_proj.weight"
+                ] = val[:dim, :]
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.k_proj.weight"
+                ] = val[dim : dim * 2, :]
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.v_proj.weight"
+                ] = val[-dim:, :]
+            else:
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.q_proj.bias"
+                ] = val[:dim]
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.k_proj.bias"
+                ] = val[dim : dim * 2]
+                orig_state_dict[
+                    f"vision_model.encoder.stages.{stage_num}.layers.{layer_num}.self_attn.v_proj.bias"
+                ] = val[-dim:]
+        elif "in_proj" in key:
+            # weights and biases of the key, value and query projections of text encoder's attention layers require special treatment:
+            # we need to split them up into separate matrices/vectors
+            key_split = key.split(".")
+            layer_num = int(key_split[3])
+            dim = config.text_config.hidden_size
+            if "weight" in key:
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.q_proj.weight"] = val[:dim, :]
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.k_proj.weight"] = val[
+                    dim : dim * 2, :
+                ]
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.v_proj.weight"] = val[-dim:, :]
+            else:
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.q_proj.bias"] = val[:dim]
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.k_proj.bias"] = val[dim : dim * 2]
+                orig_state_dict[f"text_model.encoder.layers.{layer_num}.self_attn.v_proj.bias"] = val[-dim:]
         else:
             new_name = rename_key(key)
             # squeeze if necessary
@@ -103,8 +144,15 @@ def convert_state_dict(orig_state_dict):
     return orig_state_dict
 
 
+# We will verify our results on an image of cute cats
+def prepare_img():
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    im = Image.open(requests.get(url, stream=True).raw)
+    return im
+
+
 @torch.no_grad()
-def convert_groupvit_checkpoint(checkpoint_path, pytorch_dump_folder_path):
+def convert_groupvit_checkpoint(checkpoint_path, pytorch_dump_folder_path, push_to_hub=False):
     """
     Copy/paste/tweak model's weights to the Transformers design.
     """
@@ -112,20 +160,38 @@ def convert_groupvit_checkpoint(checkpoint_path, pytorch_dump_folder_path):
     model = GroupViTModel(config).eval()
 
     state_dict = torch.load(checkpoint_path, map_location="cpu")["model"]
-    new_state_dict = convert_state_dict(state_dict)
-    del new_state_dict["multi_label_logit_scale"]
-    model.load_state_dict(new_state_dict)
+    new_state_dict = convert_state_dict(state_dict, config)
+    missing_keys, unexpected_keys = model.load_state_dict(new_state_dict, strict=False)
+    assert missing_keys == ["text_model.embeddings.position_ids"]
+    assert unexpected_keys == ["multi_label_logit_scale"]
 
-    expected_logits = torch.tensor([])
+    # verify result
+    processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+    image = prepare_img()
+    inputs = processor(text=["a photo of a cat", "a photo of a dog"], images=image, padding=True, return_tensors="pt")
+
+    with torch.no_grad():
+        outputs = model(**inputs)
+
+    expected_logits = torch.tensor([[13.3523, 6.3629]])
+    assert torch.allclose(outputs.logits_per_image, expected_logits, atol=1e-3)
 
     model.save_pretrained(pytorch_dump_folder_path)
-    print("Saved model to", pytorch_dump_folder_path)
+    print("Successfully saved model to", pytorch_dump_folder_path)
+
+    if push_to_hub:
+        print("Pushing to the hub...")
+        model_name = "groupvit-gccyfcc"
+        model.push_to_hub(model_name, organization="nielsr")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--pytorch_dump_folder_path", default=None, type=str, help="Path to the output PyTorch model.")
     parser.add_argument("--checkpoint_path", default=None, type=str, help="Path to GroupViT checkpoint")
+    parser.add_argument(
+        "--push_to_hub", action="store_true", help="Whether or not to push the converted model to the 🤗 hub."
+    )
     args = parser.parse_args()
 
-    convert_groupvit_checkpoint(args.checkpoint_path, args.pytorch_dump_folder_path)
+    convert_groupvit_checkpoint(args.checkpoint_path, args.pytorch_dump_folder_path, args.push_to_hub)

--- a/src/transformers/models/groupvit/convert_groupvit_nvlab_to_hf.py
+++ b/src/transformers/models/groupvit/convert_groupvit_nvlab_to_hf.py
@@ -44,6 +44,8 @@ def rename_key(name):
         name = name.replace("attn", "self_attn")
     if "proj" in name and "self_attn" in name and "text" not in name:
         name = name.replace("proj", "out_proj")
+    if "pre_assign_attn.attn.proj" in name:
+        name = name.replace("pre_assign_attn.attn.proj", "pre_assign_attn.attn.out_proj")
     if "norm1" in name:
         name = name.replace("norm1", "layer_norm1")
     if "norm2" in name and "pre_assign" not in name:

--- a/src/transformers/models/groupvit/modeling_groupvit.py
+++ b/src/transformers/models/groupvit/modeling_groupvit.py
@@ -18,7 +18,7 @@
 import collections.abc
 import math
 from dataclasses import dataclass
-from typing import Any, Optional, Set, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -27,7 +27,7 @@ from torch import nn
 
 from ...activations import ACT2FN
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
-from ...modeling_utils import PreTrainedModel, find_pruneable_heads_and_indices, prune_linear_layer
+from ...modeling_utils import PreTrainedModel
 from ...utils import (
     ModelOutput,
     add_start_docstrings,
@@ -167,7 +167,23 @@ def get_grouping_from_attentions(attentions, hw_shape):
     return final_grouping
 
 
-class GroupViTAttention(nn.Module):
+class GroupViTCrossAttentionLayer(nn.Module):
+    def __init__(self, config: GroupViTVisionConfig):
+        super().__init__()
+        self.attn = GroupViTCrossAttention(config)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = GroupViTMLP(config)
+        self.norm_post = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def forward(self, query, key):
+        x = query
+        x = x + self.attn(query, key)
+        x = x + self.mlp(self.norm2(x))
+        x = self.norm_post(x)
+        return x
+
+
+class GroupViTCrossAttention(nn.Module):
     def __init__(self, config: GroupViTVisionConfig):
         super().__init__()
         self.num_heads = config.num_attention_heads
@@ -213,22 +229,6 @@ class GroupViTAttention(nn.Module):
         out = (attn @ value).transpose(1, 2).reshape(batch_size, query_length, channels)
         out = self.proj(out)
         return out
-
-
-class GroupViTCrossAttentionLayer(nn.Module):
-    def __init__(self, config: GroupViTVisionConfig):
-        super().__init__()
-        self.attn = GroupViTAttention(config)
-        self.norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-        self.mlp = GroupViTMLP(config)
-        self.norm_post = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-
-    def forward(self, query, key):
-        x = query
-        x = x + self.attn(query, key)
-        x = x + self.mlp(self.norm2(x))
-        x = self.norm_post(x)
-        return x
 
 
 class GroupViTAssignAttention(nn.Module):
@@ -386,7 +386,7 @@ class GroupViTModelOutput(ModelOutput):
         )
 
 
-class PatchEmbeddings(nn.Module):
+class GroupViTPatchEmbeddings(nn.Module):
     """
     Image to Patch Embedding.
     """
@@ -424,7 +424,7 @@ class GroupViTVisionEmbeddings(nn.Module):
     def __init__(self, config: GroupViTVisionConfig):
         super().__init__()
 
-        self.patch_embeddings = PatchEmbeddings(
+        self.patch_embeddings = GroupViTPatchEmbeddings(
             image_size=config.image_size,
             patch_size=config.patch_size,
             num_channels=config.num_channels,
@@ -432,7 +432,7 @@ class GroupViTVisionEmbeddings(nn.Module):
         )
         num_patches = self.patch_embeddings.num_patches
         self.position_embeddings = nn.Parameter(torch.zeros(1, num_patches, config.hidden_size))
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.dropout = nn.Dropout(config.dropout)
         self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.config = config
 
@@ -524,8 +524,132 @@ class GroupViTTextEmbeddings(nn.Module):
         return embeddings
 
 
-# Copied from transformers.models.clip.modeling_clip.CLIPAttention with CLIP->GroupViTText
-class GroupViTTextAttention(nn.Module):
+class GroupViTStage(nn.Module):
+    """This corresponds to the `GroupingLayer` class in the GroupViT implementation."""
+
+    def __init__(
+        self,
+        config: GroupViTVisionConfig,
+        depth: int,
+        num_prev_group_token: int,
+        num_group_token: int,
+        num_output_group: int,
+    ):
+        super().__init__()
+        self.depth = depth
+        self.num_group_token = num_group_token
+        if num_group_token > 0:
+            self.group_token = nn.Parameter(torch.zeros(1, num_group_token, config.hidden_size))
+        else:
+            self.group_token = None
+        self.gradient_checkpointing = False
+        self.layers = nn.ModuleList([GroupViTEncoderLayer(config) for _ in range(depth)])
+
+        if num_group_token > 0:
+            self.downsample = GroupViTTokenAssign(
+                config=config,
+                num_group_token=num_group_token,
+                num_output_group=num_output_group,
+            )
+        else:
+            self.downsample = None
+
+        if num_prev_group_token > 0 and num_group_token > 0:
+            self.group_projector = nn.Sequential(
+                nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps),
+                GroupViTMixerMLP(config, num_prev_group_token, config.hidden_size // 2, num_group_token),
+            )
+        else:
+            self.group_projector = None
+
+    @property
+    def with_group_token(self):
+        return self.group_token is not None
+
+    def split_x(self, x):
+        if self.with_group_token:
+            return x[:, : -self.num_group_token], x[:, -self.num_group_token :]
+        else:
+            return x, None
+
+    def concat_x(self, x: torch.Tensor, group_token: Optional[torch.Tensor] = None) -> torch.Tensor:
+        if group_token is None:
+            return x
+        return torch.cat([x, group_token], dim=1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        prev_group_token: Optional[torch.Tensor] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.FloatTensor]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`): attention mask of size
+                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
+                `(config.encoder_attention_heads,)`.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the grouping tensors of Grouping block.
+        """
+        if self.with_group_token:
+            group_token = self.group_token.expand(hidden_states.size(0), -1, -1)
+            if self.group_projector is not None:
+                group_token = group_token + self.group_projector(prev_group_token)
+        else:
+            group_token = None
+
+        x = hidden_states
+
+        cat_x = self.concat_x(x, group_token)
+        for layer in self.layers:
+            layer_out = layer(cat_x, attention_mask=None, causal_attention_mask=None)
+            cat_x = layer_out[0]
+
+        x, group_token = self.split_x(cat_x)
+
+        attention = None
+        if self.downsample is not None:
+            x, attention = self.downsample(x, group_token)
+
+        outputs = (x, group_token)
+        if output_attentions:
+            outputs = outputs + (attention,)
+
+        return outputs
+
+
+class GroupViTMLP(nn.Module):
+    def __init__(
+        self,
+        config: GroupViTVisionConfig,
+        hidden_size: Optional[int] = None,
+        intermediate_size: Optional[int] = None,
+        output_size: Optional[int] = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.activation_fn = ACT2FN[config.hidden_act]
+        hidden_size = hidden_size if hidden_size is not None else config.hidden_size
+        intermediate_size = intermediate_size if intermediate_size is not None else config.intermediate_size
+        output_size = output_size if output_size is not None else hidden_size
+        self.fc1 = nn.Linear(hidden_size, intermediate_size)
+        self.fc2 = nn.Linear(intermediate_size, output_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class GroupViTMixerMLP(GroupViTMLP):
+    def forward(self, x):
+        return super().forward(x.transpose(1, 2)).transpose(1, 2)
+
+
+# Copied from transformers.models.clip.modeling_clip.CLIPAttention with CLIP->GroupViT
+class GroupViTAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
     def __init__(self, config):
@@ -629,328 +753,12 @@ class GroupViTTextAttention(nn.Module):
         return attn_output, attn_weights_reshaped
 
 
-# Copied from transformers.models.vit.modeling_vit.ViTSelfAttention with ViT->GroupViT
-class GroupViTSelfAttention(nn.Module):
-    def __init__(self, config: GroupViTConfig) -> None:
-        super().__init__()
-        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
-            raise ValueError(
-                f"The hidden size {config.hidden_size,} is not a multiple of the number of attention "
-                f"heads {config.num_attention_heads}."
-            )
-
-        self.num_attention_heads = config.num_attention_heads
-        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
-        self.all_head_size = self.num_attention_heads * self.attention_head_size
-
-        self.query = nn.Linear(config.hidden_size, self.all_head_size, bias=config.qkv_bias)
-        self.key = nn.Linear(config.hidden_size, self.all_head_size, bias=config.qkv_bias)
-        self.value = nn.Linear(config.hidden_size, self.all_head_size, bias=config.qkv_bias)
-
-        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
-
-    def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
-        new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
-        x = x.view(new_x_shape)
-        return x.permute(0, 2, 1, 3)
-
-    def forward(
-        self, hidden_states, head_mask: Optional[torch.Tensor] = None, output_attentions: bool = False
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor]]:
-        mixed_query_layer = self.query(hidden_states)
-
-        key_layer = self.transpose_for_scores(self.key(hidden_states))
-        value_layer = self.transpose_for_scores(self.value(hidden_states))
-        query_layer = self.transpose_for_scores(mixed_query_layer)
-
-        # Take the dot product between "query" and "key" to get the raw attention scores.
-        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
-
-        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
-
-        # Normalize the attention scores to probabilities.
-        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
-
-        # This is actually dropping out entire tokens to attend to, which might
-        # seem a bit unusual, but is taken from the original Transformer paper.
-        attention_probs = self.dropout(attention_probs)
-
-        # Mask heads if we want to
-        if head_mask is not None:
-            attention_probs = attention_probs * head_mask
-
-        context_layer = torch.matmul(attention_probs, value_layer)
-
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
-        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(new_context_layer_shape)
-
-        outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
-
-        return outputs
-
-
-# Copied from transformers.models.vit.modeling_vit.ViTSelfOutput with ViT->GroupViT
-class GroupViTSelfOutput(nn.Module):
-    """
-    The residual connection is defined in GroupViTLayer instead of here (as is the case with other models), due to the
-    layernorm applied before each block.
-    """
-
-    def __init__(self, config: GroupViTConfig) -> None:
-        super().__init__()
-        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
-
-    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
-
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
-
-        return hidden_states
-
-
-# Copied from transformers.models.vit.modeling_vit.ViTAttention with ViT->GroupViT
-class GroupViTVisionAttention(nn.Module):
-    def __init__(self, config: GroupViTConfig) -> None:
-        super().__init__()
-        self.attention = GroupViTSelfAttention(config)
-        self.output = GroupViTSelfOutput(config)
-        self.pruned_heads = set()
-
-    def prune_heads(self, heads: Set[int]) -> None:
-        if len(heads) == 0:
-            return
-        heads, index = find_pruneable_heads_and_indices(
-            heads, self.attention.num_attention_heads, self.attention.attention_head_size, self.pruned_heads
-        )
-
-        # Prune linear layers
-        self.attention.query = prune_linear_layer(self.attention.query, index)
-        self.attention.key = prune_linear_layer(self.attention.key, index)
-        self.attention.value = prune_linear_layer(self.attention.value, index)
-        self.output.dense = prune_linear_layer(self.output.dense, index, dim=1)
-
-        # Update hyper params and store pruned heads
-        self.attention.num_attention_heads = self.attention.num_attention_heads - len(heads)
-        self.attention.all_head_size = self.attention.attention_head_size * self.attention.num_attention_heads
-        self.pruned_heads = self.pruned_heads.union(heads)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        head_mask: Optional[torch.Tensor] = None,
-        output_attentions: bool = False,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor]]:
-        self_outputs = self.attention(hidden_states, head_mask, output_attentions)
-
-        attention_output = self.output(self_outputs[0], hidden_states)
-
-        outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
-        return outputs
-
-
-# Copied from transformers.models.vit.modeling_vit.ViTIntermediate with ViT->GroupViT
-class GroupViTIntermediate(nn.Module):
-    def __init__(self, config: GroupViTConfig) -> None:
-        super().__init__()
-        self.dense = nn.Linear(config.hidden_size, config.intermediate_size)
-        if isinstance(config.hidden_act, str):
-            self.intermediate_act_fn = ACT2FN[config.hidden_act]
-        else:
-            self.intermediate_act_fn = config.hidden_act
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.intermediate_act_fn(hidden_states)
-
-        return hidden_states
-
-
-# Copied from transformers.models.vit.modeling_vit.ViTOutput with ViT->GroupViTVision
-class GroupViTVisionOutput(nn.Module):
-    def __init__(self, config: GroupViTVisionConfig) -> None:
-        super().__init__()
-        self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
-
-    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
-        hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
-
-        hidden_states = hidden_states + input_tensor
-
-        return hidden_states
-
-
-class GroupViTVisionLayer(nn.Module):
-    def __init__(self, config: GroupViTVisionConfig) -> None:
-        super().__init__()
-        self.attention = GroupViTVisionAttention(config)
-        self.intermediate = GroupViTIntermediate(config)
-        self.output = GroupViTVisionOutput(config)
-        self.layernorm_before = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-        self.layernorm_after = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        head_mask: Optional[torch.Tensor] = None,
-        output_attentions: bool = False,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor]]:
-        self_attention_outputs = self.attention(
-            self.layernorm_before(hidden_states),  # in GroupViTVision, layernorm is applied before self-attention
-            head_mask,
-            output_attentions=output_attentions,
-        )
-        attention_output = self_attention_outputs[0]
-        outputs = self_attention_outputs[1:]  # add self attentions if we output attention weights
-
-        # first residual connection
-        hidden_states = attention_output + hidden_states
-
-        # in GroupViTVision, layernorm is also applied after self-attention
-        layer_output = self.layernorm_after(hidden_states)
-        layer_output = self.intermediate(layer_output)
-
-        # second residual connection is done here
-        layer_output = self.output(layer_output, hidden_states)
-
-        outputs = (layer_output,) + outputs
-
-        return outputs
-
-
-class GroupViTStage(nn.Module):
-    """This corresponds to the `GroupingLayer` class in the GroupViT implementation."""
-
-    def __init__(
-        self,
-        config: GroupViTVisionConfig,
-        depth: int,
-        num_prev_group_token: int,
-        num_group_token: int,
-        num_output_group: int,
-    ):
-        super().__init__()
-        self.depth = depth
-        self.num_group_token = num_group_token
-        if num_group_token > 0:
-            self.group_token = nn.Parameter(torch.zeros(1, num_group_token, config.hidden_size))
-        else:
-            self.group_token = None
-        self.gradient_checkpointing = False
-        self.layers = nn.ModuleList([GroupViTVisionLayer(config) for _ in range(depth)])
-
-        if num_group_token > 0:
-            self.downsample = GroupViTTokenAssign(
-                config=config,
-                num_group_token=num_group_token,
-                num_output_group=num_output_group,
-            )
-        else:
-            self.downsample = None
-
-        if num_prev_group_token > 0 and num_group_token > 0:
-            self.group_projector = nn.Sequential(
-                nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps),
-                GroupViTMixerMLP(config, num_prev_group_token, config.hidden_size // 2, num_group_token),
-            )
-        else:
-            self.group_projector = None
-
-    @property
-    def with_group_token(self):
-        return self.group_token is not None
-
-    def split_x(self, x):
-        if self.with_group_token:
-            return x[:, : -self.num_group_token], x[:, -self.num_group_token :]
-        else:
-            return x, None
-
-    def concat_x(self, x: torch.Tensor, group_token: Optional[torch.Tensor] = None) -> torch.Tensor:
-        if group_token is None:
-            return x
-        return torch.cat([x, group_token], dim=1)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        prev_group_token: Optional[torch.Tensor] = None,
-        output_attentions: Optional[bool] = False,
-    ) -> Tuple[torch.FloatTensor]:
-        """
-        Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
-            attention_mask (`torch.FloatTensor`): attention mask of size
-                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
-                `(config.encoder_attention_heads,)`.
-            output_attentions (`bool`, *optional*):
-                Whether or not to return the grouping tensors of Grouping block.
-        """
-        if self.with_group_token:
-            group_token = self.group_token.expand(hidden_states.size(0), -1, -1)
-            if self.group_projector is not None:
-                group_token = group_token + self.group_projector(prev_group_token)
-        else:
-            group_token = None
-
-        x = hidden_states
-
-        cat_x = self.concat_x(x, group_token)
-        for blk in self.layers:
-            blk_out = blk(cat_x)
-            cat_x = blk_out[0]
-
-        x, group_token = self.split_x(cat_x)
-
-        attention = None
-        if self.downsample is not None:
-            x, attention = self.downsample(x, group_token)
-
-        outputs = (x, group_token)
-        if output_attentions:
-            outputs = outputs + (attention,)
-
-        return outputs
-
-
-class GroupViTMLP(nn.Module):
-    def __init__(
-        self,
-        config: GroupViTVisionConfig,
-        hidden_size: Optional[int] = None,
-        intermediate_size: Optional[int] = None,
-        output_size: Optional[int] = None,
-    ):
-        super().__init__()
-        self.config = config
-        self.activation_fn = ACT2FN[config.hidden_act]
-        hidden_size = hidden_size if hidden_size is not None else config.hidden_size
-        intermediate_size = intermediate_size if intermediate_size is not None else config.intermediate_size
-        output_size = output_size if output_size is not None else hidden_size
-        self.fc1 = nn.Linear(hidden_size, intermediate_size)
-        self.fc2 = nn.Linear(intermediate_size, output_size)
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        hidden_states = self.fc1(hidden_states)
-        hidden_states = self.activation_fn(hidden_states)
-        hidden_states = self.fc2(hidden_states)
-        return hidden_states
-
-
-class GroupViTMixerMLP(GroupViTMLP):
-    def forward(self, x):
-        return super().forward(x.transpose(1, 2)).transpose(1, 2)
-
-
-class GroupViTTextEncoderLayer(nn.Module):
-    def __init__(self, config: GroupViTTextConfig):
+# Copied from transformers.models.clip.modeling_clip.CLIPEncoderLayer with CLIP->GroupViT
+class GroupViTEncoderLayer(nn.Module):
+    def __init__(self, config: GroupViTConfig):
         super().__init__()
         self.embed_dim = config.hidden_size
-        self.self_attn = GroupViTTextAttention(config)
+        self.self_attn = GroupViTAttention(config)
         self.layer_norm1 = nn.LayerNorm(self.embed_dim)
         self.mlp = GroupViTMLP(config)
         self.layer_norm2 = nn.LayerNorm(self.embed_dim)
@@ -1025,7 +833,7 @@ class GroupViTPreTrainedModel(PreTrainedModel):
         if isinstance(module, GroupViTTextEmbeddings):
             module.token_embedding.weight.data.normal_(mean=0.0, std=factor * 0.02)
             module.position_embedding.weight.data.normal_(mean=0.0, std=factor * 0.02)
-        elif isinstance(module, GroupViTTextAttention):
+        elif isinstance(module, GroupViTAttention):
             factor = self.config.initializer_factor
             in_proj_std = (module.embed_dim**-0.5) * ((2 * module.config.num_hidden_layers) ** -0.5) * factor
             out_proj_std = (module.embed_dim**-0.5) * factor
@@ -1205,7 +1013,7 @@ class GroupViTVisionEncoder(nn.Module):
 class GroupViTTextEncoder(nn.Module):
     """
     Transformer encoder consisting of `config.num_hidden_layers` self-attention layers. Each layer is a
-    [`GroupViTTextEncoderLayer`].
+    [`GroupViTEncoderLayer`].
 
     Args:
         config: GroupViTTextConfig
@@ -1214,7 +1022,7 @@ class GroupViTTextEncoder(nn.Module):
     def __init__(self, config: GroupViTTextConfig):
         super().__init__()
         self.config = config
-        self.layers = nn.ModuleList([GroupViTTextEncoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layers = nn.ModuleList([GroupViTEncoderLayer(config) for _ in range(config.num_hidden_layers)])
         self.gradient_checkpointing = False
 
     def forward(
@@ -1510,7 +1318,7 @@ class GroupViTVisionModel(GroupViTPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def get_input_embeddings(self) -> PatchEmbeddings:
+    def get_input_embeddings(self) -> GroupViTPatchEmbeddings:
         return self.vision_model.embeddings.patch_embeddings
 
     @add_start_docstrings_to_model_forward(GROUPVIT_VISION_INPUTS_DOCSTRING)

--- a/src/transformers/models/groupvit/test.py
+++ b/src/transformers/models/groupvit/test.py
@@ -1,0 +1,20 @@
+from PIL import Image
+
+import requests
+from transformers import AutoProcessor, GroupViTConfig, GroupViTModel
+
+
+processor = AutoProcessor.from_pretrained("nvidia/groupvit-gccyfcc")
+model = GroupViTModel(GroupViTConfig()).eval()
+
+url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+image = Image.open(requests.get(url, stream=True).raw)
+
+inputs = processor(text=["a photo of a cat", "a photo of a dog"], images=image, return_tensors="pt", padding=True)
+
+for k, v in inputs.items():
+    print(k, v.shape)
+
+outputs = model(**inputs)
+logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
+probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities

--- a/src/transformers/models/groupvit/test.py
+++ b/src/transformers/models/groupvit/test.py
@@ -16,5 +16,6 @@ for k, v in inputs.items():
     print(k, v.shape)
 
 outputs = model(**inputs)
-logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
-probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities
+
+for name, param in model.named_parameters():
+    print(name, param.shape)

--- a/tests/models/groupvit/test_modeling_groupvit.py
+++ b/tests/models/groupvit/test_modeling_groupvit.py
@@ -643,7 +643,6 @@ class GroupViTModelIntegrationTest(unittest.TestCase):
     def test_inference(self):
         model_name = "nvidia/groupvit-gccyfcc"
         model = GroupViTModel.from_pretrained(model_name)
-        model.eval()
         processor = CLIPProcessor.from_pretrained(model_name)
 
         image = prepare_img()


### PR DESCRIPTION
# What does this PR do?

This PR replaces the `GroupViTVisionLayer` and `GroupViTTextEncoderLayer` by a single `GroupViTEncoderLayer` class.

UPDATE: also updated the conversion script accordingly, and now a single GroupViTAttentionClass is used for both self-attention and cross-attention.

There's also a [branch](https://github.com/NielsRogge/transformers/tree/groupvit_simplify_v2/src/transformers/models/groupvit) of mine that goes one step further, by removing the cross-attention class with a single `GroupViTAttention` class that can be used for both self- and cross-attention, but I guess this won't be possible since the scale is applied on the attention logits, rather than on the queries? UPDATE => merged this.